### PR TITLE
Fix crash when switching from active to inactive

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-env": "7.4.2",
     "@babel/preset-react": "7.0.0",
     "@babel/register": "7.4.0",
-    "mocha": "6.0.2",
+    "mocha": "^8.2.0",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-test-renderer": "^16.0.0"

--- a/src/Card.js
+++ b/src/Card.js
@@ -209,9 +209,9 @@ export default class Card extends Component {
     }
 
     // fix for svg
-    if (!parent.offsetHeight && parent.getBoundingClientRect) {
-      parentSize.width = parent.getBoundingClientRect().width
-      parentSize.height = parent.getBoundingClientRect().height
+    if (!parent.offsetHeight) {
+      parentSize.width = tooltipPosition.width
+      parentSize.height = tooltipPosition.height
     }
 
     if (align === 'left') {

--- a/src/Card.js
+++ b/src/Card.js
@@ -56,6 +56,8 @@ export default class Card extends Component {
 
   rootRef = React.createRef()
 
+  updateSizeRepetitionLimit = 0
+
   getGlobalStyle() {
     if (!this.props.parentEl) {
       return {display: 'none'}
@@ -318,11 +320,16 @@ export default class Card extends Component {
   }
 
   componentDidMount() {
+    this.updateSizeRepetitionLimit = 4
     this.updateSize()
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props !== prevProps){
+    if (this.props !== prevProps) {
+      this.updateSizeRepetitionLimit = 4
+      this.updateSize()
+    } else if (this.updateSizeRepetitionLimit) {
+      this.updateSizeRepetitionLimit--
       this.updateSize()
     }
   }

--- a/src/ToolTip.js
+++ b/src/ToolTip.js
@@ -56,7 +56,7 @@ export default class ToolTip extends React.Component {
     }
 
     const newProps = {...props}
-    if (state.wasActive && !props.active) {
+    if (portalNode && state.wasActive && !props.active) {
       newProps.active = true
       portalNode.timeout = setTimeout(() => {
         ToolTip.renderPortal({...props, active: false})


### PR DESCRIPTION
When switching to your fork of react-portal-tooltip, I experienced crashes because `portalNode` in `getDerivedStateFromProps` can be undefined. This happens if `state.wasActive` is true, `props.active` is changed to false, and no portal node has been created yet.

After fixing the crash, I still saw some unwanted changes in behavior compared to the original version. So I have refactored the code a little to make it behave like before.

I'm PRing this to you because the original repository seems to be abandoned, and people might find your fork instead, like I did.